### PR TITLE
Make CP2K an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "aiida-core",
     "aiida-workgraph",
     "aiida-quantumespresso",
-    "aiida-cp2k",
     "weas-widget>=0.1.25",
     "table-widget>=0.0.3"
 ]
@@ -38,6 +37,9 @@ Documentation = "https://aiida-bader.readthedocs.io"
 Source = "https://github.com/superstar54/aiida-bader"
 
 [project.optional-dependencies]
+cp2k = [
+    "aiida-cp2k",
+]
 docs = [
     "sphinx_rtd_theme",
     "sphinx~=7.2",


### PR DESCRIPTION
Due to the coupling of the AiiDA plugin with the QE app plugin in one repo, dependencies unrelated to the app may interfere with the app, e.g., aiida-cp2k. This PR makes that dependency optional. In principle, the app plugin part should be moved to a separate repo, or into the QE app itself (if we proceed with making the app a monorepo).